### PR TITLE
Add "Build Run Debug"

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -107,6 +107,17 @@
                 "panel": "shared"
             },
             "command": "sh ${workspaceRoot}/.vscode/testDirs.sh ${workspaceRoot} ${workspaceFolder}"
+        },
+        {
+          "type": "shell",
+          "label": "Build Run Debug",
+          "presentation": {
+            "reveal": "never",
+            "panel": "shared"
+          },
+          "command": "make",
+          "args": ["RunDebug"],
+          "dependsOn": ["Build Debug"]
         }
     ]
 }


### PR DESCRIPTION
Create single task that executes `Build Debug` before `Run Debug` to allow ability to assign a single shortcut to run both tasks.